### PR TITLE
Roles to bypass not being populated in ASMSelect

### DIFF
--- a/MaintenanceMode.module
+++ b/MaintenanceMode.module
@@ -194,7 +194,7 @@ class MaintenanceMode extends WireData implements Module, ConfigurableModule {
 		$modules = Wire::getFuel('modules');
 		$field = $modules->get("InputfieldAsmSelect");
 		$field->attr('name', $aName);
-		foreach(wire('user')->roles as $role) {
+		foreach(wire('roles') as $role) {
 			$field->addOption($role->id, $role->name); 
 		}
 		$field->attr('value', $aValue); 


### PR DESCRIPTION
The ASMSelect field for selecting roles to bypass maintenance mode is not being correctly populated by all available roles. This is due to a slight error in the code. It is currently listing the currently logged in user's roles only. 

See forum post here http://processwire.com/talk/topic/382-module-maintenance-mode/?p=38114 where this issue was first reported.
